### PR TITLE
Bug fix in error handling

### DIFF
--- a/src/errors/DatabaseError.js
+++ b/src/errors/DatabaseError.js
@@ -6,7 +6,7 @@ export default class DatabaseError extends BaseError {
     this.name = 'DatabaseErr'
     this.message = 'Data-related error'
     this.statusCode = 500
-    this.err = null
+    // this.err = null
 
     /*
     if(options) {

--- a/src/libs/errHandler.js
+++ b/src/libs/errHandler.js
@@ -10,6 +10,9 @@ const errHandler = (err, req, res, next) => {
   logger.error(err.name)
   logger.error(err.message)
   logger.error(err.stack)
+  if(err.err) {
+    logger.log(err.err)
+  }
   if(err instanceof UserFacingError) {
     return res.status(err.statusCode).json({
       err: err.name,


### PR DESCRIPTION
Removed this.err = null from constructor of DatabaseError.js and allow default error handler (errHandler.js) to print an error's err property when available.